### PR TITLE
Support modern Blockbook asset UTXOs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syscoinjs-lib",
-  "version": "1.0.272",
+  "version": "1.0.273",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syscoinjs-lib",
-      "version": "1.0.272",
+      "version": "1.0.273",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",
@@ -21,7 +21,7 @@
         "eth-object": "https://github.com/syscoin/eth-object.git",
         "eth-proof": "^2.1.6",
         "ethers": "^6.17.0",
-        "syscointx-js": "^1.0.125",
+        "syscointx-js": "^1.0.127",
         "varuint-bitcoin": "^2.0.0"
       },
       "devDependencies": {
@@ -6476,9 +6476,9 @@
       }
     },
     "node_modules/syscointx-js": {
-      "version": "1.0.125",
-      "resolved": "https://registry.npmjs.org/syscointx-js/-/syscointx-js-1.0.125.tgz",
-      "integrity": "sha512-bAiZCRC1mpphtt8W7t86+ipFXOTn4VFjBbBr+TXcaE5CfP35vxTEaI2B8YaU6D7avHZkIS3kSlSpFSdsp91jMA==",
+      "version": "1.0.127",
+      "resolved": "https://registry.npmjs.org/syscointx-js/-/syscointx-js-1.0.127.tgz",
+      "integrity": "sha512-9bZ86RxcJvs7YdwiaPIqSgP2z0HD7n0E9mb0WG4deJRfbrRXLhMczmICvwJ/yIxlKx0SgF5rmF49rrX8mNKSEw==",
       "license": "MIT",
       "dependencies": {
         "@bitcoinerlab/secp256k1": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syscoinjs-lib",
-  "version": "1.0.272",
+  "version": "1.0.273",
   "description": "A transaction creation library interfacing with coin selection for Syscoin.",
   "keywords": [
     "coinselect",
@@ -59,7 +59,7 @@
     "eth-object": "https://github.com/syscoin/eth-object.git",
     "eth-proof": "^2.1.6",
     "ethers": "^6.17.0",
-    "syscointx-js": "^1.0.125",
+    "syscointx-js": "^1.0.127",
     "varuint-bitcoin": "^2.0.0"
   }
 }

--- a/test/bridge-burn-hardening.js
+++ b/test/bridge-burn-hardening.js
@@ -54,6 +54,26 @@ function bridgeAssetOpts () {
   return { ethaddress: ETH_ADDRESS }
 }
 
+function modernBlockbookExactSysxUtxos () {
+  return [
+    {
+      txid: 'bcc5ffea63a4edebe771cbc60713ac9313b006f5dcde5e523028614e1c97a161',
+      vout: 1,
+      value: '2989998650',
+      height: 1790003,
+      confirmations: 1,
+      address: ADDRESS,
+      path: "m/84'/1'/0'/0/0",
+      assetInfo: {
+        assetGuid: TARGET_ASSET,
+        value: '10000000',
+        valueStr: '0.1',
+        symbol: 'SYSX'
+      }
+    }
+  ]
+}
+
 function utxoFixture () {
   return {
     assets: [
@@ -295,6 +315,62 @@ test('bridge burn supports BN asset GUID inputs', async t => {
 
   t.ok(captured, 'captured builder result')
   t.equal(captured.inputs.filter(input => input.assetInfo && input.assetInfo.assetGuid === TARGET_ASSET).length, 1)
+  t.end()
+})
+
+test('bridge burn accepts modern Blockbook UTXO arrays without a top-level assets collection', async t => {
+  const rawBlockbookUtxos = modernBlockbookExactSysxUtxos()
+
+  const sanitized = utils.sanitizeBlockbookUTXOs(
+    null,
+    rawBlockbookUtxos,
+    utils.syscoinNetworks.testnet,
+    {},
+    assetMapFor(TARGET_ASSET, 10000000),
+    false
+  )
+  t.ok(sanitized.assets.has(TARGET_ASSET), 'shims the legacy assets Map entry')
+  t.equal(Object.keys(sanitized.assets.get(TARGET_ASSET)).length, 0, 'does not invent missing asset properties')
+
+  const { captured } = await captureResult(syscoin => syscoin.assetAllocationBurn(
+    bridgeAssetOpts(),
+    {},
+    assetMapFor(TARGET_ASSET, 10000000),
+    ADDRESS,
+    new BN(10),
+    null,
+    rawBlockbookUtxos
+  ))
+
+  t.ok(captured, 'captured builder result')
+  t.equal(captured.inputs.length, 1, 'uses the mixed SYS/SYSX UTXO')
+  t.equal(captured.inputs[0].txId, rawBlockbookUtxos[0].txid)
+  t.equal(captured.inputs[0].assetInfo.assetGuid, TARGET_ASSET)
+
+  const decoder = new Syscoin(null, null, utils.syscoinNetworks.testnet)
+  const psbt = await decoder.createPSBTFromRes(captured)
+  const decoded = decoder.decodeRawTransaction(psbt)
+  t.equal(decoded.vin[0].assetInfo.assetGuid, TARGET_ASSET, 'keeps the consumed asset metadata on the input')
+  t.equal(decoded.vout.filter(output => output.assetInfo).length, 0, 'does not expose a false asset-bearing output to wallet confirmation UIs')
+  t.end()
+})
+
+test('asset send accepts an exact modern Blockbook SYSX UTXO', async t => {
+  const rawBlockbookUtxos = modernBlockbookExactSysxUtxos()
+  const { captured } = await captureResult(syscoin => syscoin.assetAllocationSend(
+    {},
+    assetMapFor(TARGET_ASSET, 10000000),
+    ADDRESS,
+    new BN(2),
+    null,
+    rawBlockbookUtxos
+  ))
+
+  t.ok(captured, 'captured builder result')
+  t.equal(captured.inputs.length, 1, 'uses the one mixed SYS/SYSX UTXO')
+  t.equal(captured.inputs[0].txId, rawBlockbookUtxos[0].txid)
+  t.equal(captured.outputs.filter(output => output.assetInfo).length, 1, 'creates one SYSX allocation output')
+  t.equal(captured.outputs.find(output => output.assetInfo).assetInfo.value.toString(), '10000000', 'sends the full 0.1 SYSX balance')
   t.end()
 })
 

--- a/test/bridge-burn-hardening.js
+++ b/test/bridge-burn-hardening.js
@@ -355,6 +355,28 @@ test('bridge burn accepts modern Blockbook UTXO arrays without a top-level asset
   t.end()
 })
 
+test('legacy Blockbook responses reject UTXO assets missing from the top-level assets collection', async t => {
+  const legacyUtxos = {
+    assets: [
+      { assetGuid: OTHER_ASSET, maxSupply: '100000000000', decimals: 8 }
+    ],
+    utxos: modernBlockbookExactSysxUtxos()
+  }
+  const sanitized = utils.sanitizeBlockbookUTXOs(
+    null,
+    legacyUtxos,
+    utils.syscoinNetworks.testnet,
+    {},
+    assetMapFor(TARGET_ASSET, 10000000),
+    false
+  )
+
+  t.equal(sanitized.utxos.length, 0, 'rejects inconsistent per-UTXO asset metadata')
+  t.equal(sanitized.assets.has(TARGET_ASSET), false, 'does not synthesize an entry for a legacy response')
+  t.ok(sanitized.assets.has(OTHER_ASSET), 'preserves the supplied legacy asset metadata')
+  t.end()
+})
+
 test('asset send accepts an exact modern Blockbook SYSX UTXO', async t => {
   const rawBlockbookUtxos = modernBlockbookExactSysxUtxos()
   const { captured } = await captureResult(syscoin => syscoin.assetAllocationSend(

--- a/utils.js
+++ b/utils.js
@@ -1122,6 +1122,7 @@ function sanitizeBlockbookUTXOs (sysFromXpubOrAddress, utxoObj, network, txOpts,
     txOpts = { rbf: false }
   }
   const sanitizedUtxos = { utxos: [], assets: new Map() }
+  const hasTopLevelAssets = Object.prototype.hasOwnProperty.call(utxoObj, 'assets')
   if (Array.isArray(utxoObj)) {
     utxoObj.utxos = utxoObj
   }
@@ -1156,6 +1157,9 @@ function sanitizeBlockbookUTXOs (sysFromXpubOrAddress, utxoObj, network, txOpts,
         // legacy top-level assets collection. Preserve the internal Map shape;
         // asset selection and accounting use the authoritative UTXO assetInfo.
         if (!sanitizedUtxos.assets.has(assetGuid)) {
+          if (hasTopLevelAssets) {
+            return
+          }
           sanitizedUtxos.assets.set(assetGuid, {})
         }
         // not sending this asset (assetMap) and assetWhiteList option if set with this asset will skip this check, by default this check is done and inputs will be skipped

--- a/utils.js
+++ b/utils.js
@@ -1150,14 +1150,16 @@ function sanitizeBlockbookUTXOs (sysFromXpubOrAddress, utxoObj, network, txOpts,
         newUtxo.type = 'BECH32'
       }
       if (utxo.assetInfo) {
-        newUtxo.assetInfo = { assetGuid: utxo.assetInfo.assetGuid, value: new BN(utxo.assetInfo.value) }
-        const assetObj = sanitizedUtxos.assets.get(utxo.assetInfo.assetGuid)
-        // sanity check to ensure sanitizedUtxos.assets has all of the assets being added to UTXO that are assets
-        if (!assetObj) {
-          return
+        const assetGuid = utxo.assetInfo.assetGuid
+        newUtxo.assetInfo = { assetGuid, value: new BN(utxo.assetInfo.value) }
+        // Current Blockbook returns asset metadata on each UTXO without the
+        // legacy top-level assets collection. Preserve the internal Map shape;
+        // asset selection and accounting use the authoritative UTXO assetInfo.
+        if (!sanitizedUtxos.assets.has(assetGuid)) {
+          sanitizedUtxos.assets.set(assetGuid, {})
         }
         // not sending this asset (assetMap) and assetWhiteList option if set with this asset will skip this check, by default this check is done and inputs will be skipped
-        if ((!assetMap || !assetMap.has(utxo.assetInfo.assetGuid)) && (txOpts.assetWhiteList && !txOpts.assetWhiteList.has(utxo.assetInfo.assetGuid))) {
+        if ((!assetMap || !assetMap.has(assetGuid)) && (txOpts.assetWhiteList && !txOpts.assetWhiteList.has(assetGuid))) {
           console.log('SKIPPING utxo')
           return
         }


### PR DESCRIPTION
## Summary
- accept current Blockbook UTXO arrays whose per-UTXO assetInfo is authoritative and which omit the legacy top-level assets collection
- preserve the internal assets Map shape with empty shim entries instead of inventing unavailable asset properties
- update to syscointx-js 1.0.127 for exact-balance asset burns and revert the unnecessary SYS-to-SYSX output separation fixtures
- bump syscoinjs-lib to 1.0.273

## Regressions covered
- exact 0.1 SYSX self-send from the reported single mixed SYS/SYSX UTXO succeeds at 2 sat/vB instead of reporting a 264-satoshi shortfall
- exact SYSX bridge burn consumes the mixed UTXO
- PSBT decode keeps input asset metadata but exposes no false asset-bearing ordinary output to Pali confirmation UIs

## Verification
- npm test (514/514 passing)
- npm pack --dry-run --cache /private/tmp/syscoinjs-npm-cache